### PR TITLE
fix: add json-stringify-pretty-compact as dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "rxjs-migrate",
-  "version": "0.0.7",
+  "name": "rxjs-tslint",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -315,9 +315,10 @@
       }
     },
     "json-stringify-pretty-compact": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.0.4.tgz",
-      "integrity": "sha1-1RYRMb4n/ZdIORNgWX/MolDGxc4="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.1.0.tgz",
+      "integrity": "sha512-KlHWclgmjtRCbMdUxCJY8AZAIlJLeH0lu3VO9ocaY5Lndfc24YvCOUe3izrIcA8A53uCNIolAXsxouDOWj5kww==",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -513,11 +514,6 @@
       "requires": {
         "source-map": "0.5.7"
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "js-yaml": "^3.8.4",
+    "json-stringify-pretty-compact": "^1.1.0",
     "mocha": "3.0.2",
     "rimraf": "^2.5.2",
     "ts-node": "^3.3.0",


### PR DESCRIPTION
After a fresh install the tests won't run because `json-stringify-pretty-compact` is needed.



