### PR TITLE
feat(rules): migrate static operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ dist
 npm-debug.log
 .vscode
 yarn.lock
+demo.ts
+tsconfig-demo.json
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ TSLint rules for rxjs.
 
 This repository provides the following rules:
 
-|            Rule Name            | Configuration |                       Description                       |
-| :-----------------------------: | :-----------: | :-----------------------------------------------------: |
-|     `collapse-rxjs-imports`     |     none      | Collapses multiple imports from `rxjs` to a single one. |
-| `migrate-to-pipeable-operators` |     none      |      Migrates side-effect operators to pipeables.       |
-|      `update-rxjs-imports`      |     none      |         Updates RxJS 5.x.x imports to RxJS 6.0          |
+|              Rule Name              | Configuration |                       Description                       |
+| :---------------------------------: | :-----------: | :-----------------------------------------------------: |
+|       `collapse-rxjs-imports`       |     none      | Collapses multiple imports from `rxjs` to a single one. |
+|   `migrate-to-pipeable-operators`   |     none      |      Migrates side-effect operators to pipeables.       |
+| `migrate-static-observable-methods` |     none      |        Migrates static `Observable` method calls        |
+|        `update-rxjs-imports`        |     none      |         Updates RxJS 5.x.x imports to RxJS 6.0          |
 
 ## Migration to RxJS 6
 
@@ -30,6 +31,7 @@ npm i rxjs-tslint
   "rules": {
     "update-rxjs-imports": true,
     "migrate-to-pipeable-operators": true,
+    "migrate-static-observable-methods": true,
     "collapse-rxjs-imports": true
   }
 }
@@ -51,4 +53,3 @@ npm i rxjs-tslint
 ## License
 
 MIT
-

--- a/migrate-tslint.json
+++ b/migrate-tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "update-rxjs-imports": true,
     "migrate-to-pipeable-operators": true,
+    "migrate-static-observable-methods": true,
     "collapse-rxjs-imports": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,6 +494,14 @@
         "glob": "7.0.5"
       }
     },
+    "rxjs": {
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -544,6 +552,11 @@
       "requires": {
         "has-flag": "1.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "ts-node": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -7,29 +7,25 @@
     "docs": "ts-node build/buildDocs.ts",
     "lint": "tslint -c tslint.json \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
-    "release": "npm run build && rimraf dist && tsc -p tsconfig-release.json && npm run copy:common && npm run prepare:package && BUILD_TYPE=prod npm run set:vars",
+    "release":
+      "npm run build && rimraf dist && tsc -p tsconfig-release.json && npm run copy:common && npm run prepare:package && BUILD_TYPE=prod npm run set:vars",
     "build": "rimraf dist && tsc && npm run lint && npm t",
     "copy:common": "cp README.md dist",
     "prepare:package": "cat package.json | ts-node build/package.ts > dist/package.json",
     "test": "rimraf dist && tsc && mocha -R nyan dist/test --recursive",
-    "test:watch": "rimraf dist && tsc && BUILD_TYPE=dev npm run set:vars && mocha -R nyan dist/test --watch --recursive",
+    "test:watch":
+      "rimraf dist && tsc && BUILD_TYPE=dev npm run set:vars && mocha -R nyan dist/test --watch --recursive",
     "set:vars": "ts-node build/vars.ts --src ./dist",
     "tscv": "tsc --version",
     "tsc": "tsc",
     "tsc:watch": "tsc --w"
   },
-  "contributors": [
-    "Minko Gechev <mgechev@gmail.com>"
-  ],
+  "contributors": ["Minko Gechev <mgechev@gmail.com>"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mgechev/tslint-rules.git"
   },
-  "keywords": [
-    "rxjs",
-    "lint",
-    "tslint"
-  ],
+  "keywords": ["rxjs", "lint", "tslint"],
   "author": {
     "name": "Minko Gechev",
     "email": "mgechev@gmail.com"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Rule as CollapseRxjsImports } from './collapseRxjsImportsRule';
 export { Rule as UpdateRxjsImports } from './updateRxjsImportsRule';
 export { Rule as MigrateToPipeableOperators } from './migrateToPipeableOperatorsRule';
+export { Rule as MigrateStaticObservableMethods } from './migrateStaticObservableMethodsRule';

--- a/src/migrateStaticObservableMethodsRule.ts
+++ b/src/migrateStaticObservableMethodsRule.ts
@@ -1,0 +1,182 @@
+// Original author Bowen Ni
+// Modifications mgechev.
+
+import * as Lint from 'tslint';
+import * as tsutils from 'tsutils';
+import * as ts from 'typescript';
+import { subtractSets, concatSets, isObservable, returnsObservable, computeInsertionIndexForImports } from './utils';
+/**
+ * A typed TSLint rule that inspects observable chains using patched RxJs
+ * operators and turns them into a pipeable operator chain.
+ */
+export class Rule extends Lint.Rules.TypedRule {
+  static metadata: Lint.IRuleMetadata = {
+    ruleName: 'migrate-static-observable-methods',
+    description: 'Updates the static methods of the Observable class.',
+    optionsDescription: '',
+    options: null,
+    typescriptOnly: true,
+    type: 'functionality'
+  };
+  static IMPORT_FAILURE_STRING = 'prefer operator imports with no side-effects';
+  static OBSERVABLE_FAILURE_STRING = 'prefer function calls';
+
+  applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): Lint.RuleFailure[] {
+    const failure = this.applyWithFunction(sourceFile, ctx => this.walk(ctx, program));
+    return failure;
+  }
+  private walk(ctx: Lint.WalkContext<void>, program: ts.Program) {
+    this.removePatchedOperatorImports(ctx);
+    const sourceFile = ctx.sourceFile;
+    const typeChecker = program.getTypeChecker();
+    const insertionStart = computeInsertionIndexForImports(sourceFile);
+    let rxjsOperatorImports = findImportedRxjsOperators(sourceFile);
+
+    function checkPatchableOperatorUsage(node: ts.Node) {
+      if (!isRxjsStaticOperatorCallExpression(node, typeChecker)) {
+        return ts.forEachChild(node, checkPatchableOperatorUsage);
+      }
+
+      const callExpr = node as ts.CallExpression;
+      if (!tsutils.isPropertyAccessExpression(callExpr.expression)) {
+        return ts.forEachChild(node, checkPatchableOperatorUsage);
+      }
+
+      const propAccess = callExpr.expression as ts.PropertyAccessExpression;
+      const name = propAccess.name.getText(sourceFile);
+      const operatorName = OPERATOR_RENAMES[name] || name;
+      const start = propAccess.getStart(sourceFile);
+      const end = propAccess.getEnd();
+      const operatorsToImport = new Set<string>([operatorName]);
+      const operatorsToAdd = subtractSets(operatorsToImport, rxjsOperatorImports);
+      const imports = createImportReplacements(operatorsToAdd, insertionStart);
+      rxjsOperatorImports = concatSets(rxjsOperatorImports, operatorsToAdd);
+      ctx.addFailure(
+        start,
+        end,
+        Rule.OBSERVABLE_FAILURE_STRING,
+        [Lint.Replacement.replaceFromTo(start, end, operatorAlias(operatorName))].concat(imports)
+      );
+      return ts.forEachChild(node, checkPatchableOperatorUsage);
+    }
+
+    return ts.forEachChild(ctx.sourceFile, checkPatchableOperatorUsage);
+  }
+
+  private removePatchedOperatorImports(ctx: Lint.WalkContext<void>): void {
+    const sourceFile = ctx.sourceFile;
+    for (const importStatement of sourceFile.statements.filter(tsutils.isImportDeclaration)) {
+      const moduleSpecifier = importStatement.moduleSpecifier.getText();
+      if (!moduleSpecifier.startsWith(`'rxjs/add/observable/`)) {
+        continue;
+      }
+      const importStatementStart = importStatement.getStart(sourceFile);
+      const importStatementEnd = importStatement.getEnd();
+      ctx.addFailure(
+        importStatementStart,
+        importStatementEnd,
+        Rule.IMPORT_FAILURE_STRING,
+        Lint.Replacement.deleteFromTo(importStatementStart, importStatementEnd)
+      );
+    }
+  }
+}
+
+function isRxjsStaticOperator(node: ts.PropertyAccessExpression) {
+  return 'Observable' === node.expression.getText() && RXJS_OPERATORS.has(node.name.getText());
+}
+
+function isRxjsStaticOperatorCallExpression(node: ts.Node, typeChecker: ts.TypeChecker) {
+  // Expression is of the form fn()
+  if (!tsutils.isCallExpression(node)) {
+    return false;
+  }
+  // Expression is of the form foo.fn
+  if (!tsutils.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+  // fn is one of RxJs instance operators
+  if (!isRxjsStaticOperator(node.expression)) {
+    return false;
+  }
+  // fn(): k. Checks if k is an observable. Required to distinguish between
+  // array operators with same name as RxJs operators.
+  if (!returnsObservable(node, typeChecker)) {
+    return false;
+  }
+  return true;
+}
+
+function findImportedRxjsOperators(sourceFile: ts.SourceFile): Set<string> {
+  return new Set<string>(
+    sourceFile.statements.filter(tsutils.isImportDeclaration).reduce((current, decl) => {
+      if (!decl.importClause) {
+        return current;
+      }
+      if (!decl.moduleSpecifier.getText().startsWith(`'rxjs'`)) {
+        return current;
+      }
+      if (!decl.importClause.namedBindings) {
+        return current;
+      }
+      const bindings = decl.importClause.namedBindings;
+      if (ts.isNamedImports(bindings)) {
+        return [
+          ...current,
+          ...(Array.from(bindings.elements) || []).map(element => {
+            return element.name.getText();
+          })
+        ];
+      }
+      return current;
+    }, [])
+  );
+}
+
+function operatorAlias(operator: string) {
+  return 'observable' + operator[0].toUpperCase() + operator.substring(1, operator.length);
+}
+
+function createImportReplacements(operatorsToAdd: Set<string>, startIndex: number): Lint.Replacement[] {
+  return [...Array.from(operatorsToAdd.values())].map(operator =>
+    Lint.Replacement.appendText(startIndex, `\nimport {${operator} as ${operatorAlias(operator)}} from 'rxjs';\n`)
+  );
+}
+
+/*
+ * https://github.com/ReactiveX/rxjs/tree/master/compat/add/observable
+ */
+const RXJS_OPERATORS = new Set([
+  'bindCallback',
+  'bindNodeCallback',
+  'combineLatest',
+  'concat',
+  'defer',
+  'empty',
+  'forkJoin',
+  'from',
+  'fromEvent',
+  'fromEventPattern',
+  'fromPromise',
+  'generate',
+  'if',
+  'interval',
+  'merge',
+  'never',
+  'of',
+  'onErrorResumeNext',
+  'pairs',
+  'rase',
+  'range',
+  'throw',
+  'timer',
+  'using',
+  'zip'
+]);
+
+// Not handling NEVER
+const OPERATOR_RENAMES: { [key: string]: string } = {
+  throw: 'throwError',
+  if: 'iif',
+  fromPromise: 'from'
+};

--- a/src/migrateStaticObservableMethodsRule.ts
+++ b/src/migrateStaticObservableMethodsRule.ts
@@ -174,7 +174,7 @@ const RXJS_OPERATORS = new Set([
   'zip'
 ]);
 
-// Not handling NEVER
+// Not handling NEVER and EMPTY
 const OPERATOR_RENAMES: { [key: string]: string } = {
   throw: 'throwError',
   if: 'iif',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,24 @@
 import * as ts from 'typescript';
 import * as tsutils from 'tsutils';
 
+/**
+ * Returns a new Set that contains elements present in the {@link source} but
+ * not present in {@link target}
+ */
 export function subtractSets<T>(source: Set<T>, target: Set<T>): Set<T> {
   return new Set([...Array.from(source.values())].filter(x => !target.has(x)));
 }
 
+/**
+ * Returns a new Set that contains union of the two input sets.
+ */
 export function concatSets<T>(set1: Set<T>, set2: Set<T>): Set<T> {
   return new Set([...Array.from(set1.values()), ...Array.from(set2.values())]);
 }
 
+/**
+ * Returns true if the {@link type} is an Observable or one of its sub-classes.
+ */
 export function isObservable(type: ts.Type, tc: ts.TypeChecker): boolean {
   if (tsutils.isTypeReference(type)) {
     type = type.target;
@@ -32,6 +42,10 @@ export function returnsObservable(node: ts.CallLikeExpression, tc: ts.TypeChecke
   return isObservable(returnType, tc);
 }
 
+/**
+ * Returns the index to be used for inserting import statements potentially
+ * after a leading file overview comment (separated from the file with \n\n).
+ */
 export function computeInsertionIndexForImports(sourceFile: ts.SourceFile): number {
   const comments = ts.getLeadingCommentRanges(sourceFile.getFullText(), 0) || [];
   if (comments.length > 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,44 @@
+import * as ts from 'typescript';
+import * as tsutils from 'tsutils';
+
+export function subtractSets<T>(source: Set<T>, target: Set<T>): Set<T> {
+  return new Set([...Array.from(source.values())].filter(x => !target.has(x)));
+}
+
+export function concatSets<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+  return new Set([...Array.from(set1.values()), ...Array.from(set2.values())]);
+}
+
+export function isObservable(type: ts.Type, tc: ts.TypeChecker): boolean {
+  if (tsutils.isTypeReference(type)) {
+    type = type.target;
+  }
+  if (type.symbol !== undefined && type.symbol.name === 'Observable') {
+    return true;
+  }
+  if (tsutils.isUnionOrIntersectionType(type)) {
+    return type.types.some(t => isObservable(t, tc));
+  }
+  const bases = type.getBaseTypes();
+  return bases !== undefined && bases.some(t => isObservable(t, tc));
+}
+
+export function returnsObservable(node: ts.CallLikeExpression, tc: ts.TypeChecker) {
+  const signature = tc.getResolvedSignature(node);
+  if (signature === undefined) {
+    return false;
+  }
+  const returnType = tc.getReturnTypeOfSignature(signature);
+  return isObservable(returnType, tc);
+}
+
+export function computeInsertionIndexForImports(sourceFile: ts.SourceFile): number {
+  const comments = ts.getLeadingCommentRanges(sourceFile.getFullText(), 0) || [];
+  if (comments.length > 0) {
+    const commentEnd = comments[0].end;
+    if (sourceFile.text.substring(commentEnd, commentEnd + 2) === '\n\n') {
+      return commentEnd + 2;
+    }
+  }
+  return sourceFile.getFullStart();
+}


### PR DESCRIPTION
Fix #10

The rule does not handle `never`. The transformation performs the following algorithm:

- Removes all side-effect imports to static `Observable` operators.
- Finds all `Observable.[operator]` `CallExpression`s.
- Finds the operator rename (i.e. `throw` becomes `throwError`).
- Replaces `Observable.[operator]` with `Observable.[alias(rename[operator])]`.
- The alias is `observable[OperatorName]`, used in order to reduce the possibility of naming collisions with user defined functions.
- Adds import statement for the operator of the type `import { operator as OperatorAlias } from 'rxjs';`