### PR TITLE
Fix for Windows users with spaces in file names

### DIFF
--- a/src/rxjs-5-to-6-migrate.ts
+++ b/src/rxjs-5-to-6-migrate.ts
@@ -9,11 +9,11 @@ if (!argv.p) {
 }
 
 const command =
-  join(__dirname, 'node_modules', '.bin', 'tslint') +
+  '"' + join(__dirname, 'node_modules', '.bin', 'tslint') + '"' +
   ' -c ' +
-  join(__dirname, 'rxjs-5-to-6-migrate.json') +
+  '"' + join(__dirname, 'rxjs-5-to-6-migrate.json') + '"' +
   ' -p ' +
-  argv.p +
+  '"' + argv.p + '"' +
   ' --fix';
 
 const migrate = () => {


### PR DESCRIPTION
The file path currently is not escaped and uses absolute paths. If, for example, your user name in Windows is "First Last", your path will look like "C:\User\First Last\..." for all of the above files, breaking the install. My changes fix the issues.