### PR TITLE
TypeScript as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,14 +49,15 @@
     "json-stringify-pretty-compact": "^1.1.0",
     "mocha": "3.0.2",
     "rimraf": "^2.5.2",
-    "ts-node": "^3.3.0"
+    "ts-node": "^3.3.0",
+    "typescript": "^2.8.3"
   },
   "peerDependencies": {
-    "tslint": "^5.0.0"
+    "tslint": "^5.0.0",
+    "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
   },
   "dependencies": {
     "tslint": "^5.9.1",
-    "typescript": "^2.8.3",
     "chalk": "^2.4.0",
     "optimist": "^0.6.1",
     "tsutils": "^2.25.0"


### PR DESCRIPTION
This is fix for https://github.com/ReactiveX/rxjs-tslint/issues/44

We got project that uses typescript 2.7.x and after `rxjs-tslint` installation yarn added `typescript 2.8.3` as dependency of `tsutils`. It causes that `tslint` is using `2.7.x` but `tsutils` is using `2.7.x` and errors from issue #44 appears.