### PR TITLE
add typescript to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs-tslint",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -722,8 +722,7 @@
     "typescript": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
-      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
-      "dev": true
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw=="
     },
     "v8flags": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "json-stringify-pretty-compact": "^1.1.0",
     "mocha": "3.0.2",
     "rimraf": "^2.5.2",
-    "ts-node": "^3.3.0",
-    "typescript": "^2.8.3"
+    "ts-node": "^3.3.0"
   },
   "peerDependencies": {
     "tslint": "^5.0.0",
@@ -65,6 +64,7 @@
     "tslint": "^5.9.1",
     "chalk": "^2.4.0",
     "optimist": "^0.6.1",
-    "tsutils": "^2.25.0"
+    "tsutils": "^2.25.0",
+    "typescript": "^2.8.3"
   }
 }


### PR DESCRIPTION
Currently, before using rxjs-tslint, Typescript need to be installed globally. So, we can add typescript to dependencies to avoid that