### PR TITLE
fix: tslint and typescript should not be dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
     "json-stringify-pretty-compact": "^1.1.0",
     "mocha": "^5.2.0",
     "rimraf": "^2.5.2",
-    "ts-node": "^3.3.0"
+    "ts-node": "^3.3.0",
+    "tslint": "^5.9.1",
+    "typescript": ">=2.8.3"
   },
   "peerDependencies": {
     "tslint": "^5.0.0",
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
   },
   "dependencies": {
-    "tslint": "^5.9.1",
     "chalk": "^2.4.0",
     "optimist": "^0.6.1",
-    "tsutils": "^2.25.0",
-    "typescript": ">=2.8.3"
+    "tsutils": "^2.25.0"
   }
 }


### PR DESCRIPTION
@mgechev They have already been declared as `peerDependencies`.

Listing them as `dependencies` resolve a lot of issues like following when upgrading deps:

```sh
error An unexpected error occurred: "could not find a copy of typescript to link in ...\\node_modules\\rxjs-tslint\\node_modules".
```