### PR TITLE
Fix: security prototype pollution #70

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,11 @@
         "chalk": "*"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -31,16 +36,25 @@
       "integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q==",
       "dev": true
     },
-    "@types/optimist": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/optimist/-/optimist-0.0.29.tgz",
-      "integrity": "sha1-qIc1gLOoS2msHmhzI7Ffu+uQR5o=",
-      "dev": true
-    },
     "@types/sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "integrity": "sha512-h8jF5yPUoHH1QUIDfHgqFs7Y0UykKB5CJ1Z32PHGmHRLmW0pI+kYKAEnXVqeUZ3ygFmDkyvhD4vUZN+RZyTd1w==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "15.0.4",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/@types/yargs/-/yargs-15.0.4.tgz",
+      "integrity": "sha1-fl0PjKJenVhJ8upEPPfEAt7Ngpk=",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha1-yz+fdBhp4gzOMw/765JxWQSDiC0=",
       "dev": true
     },
     "ansi-regex": {
@@ -135,6 +149,11 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+    },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
@@ -160,6 +179,31 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "color-convert": {
@@ -194,6 +238,11 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
     "deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
@@ -216,6 +265,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -231,10 +285,24 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "glob": {
       "version": "7.1.3",
@@ -297,6 +365,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -317,6 +390,14 @@
       "integrity": "sha512-/11Pj1OyX814QMKO7K8l85SHPTr/KsFxHp8GE2zVa0BtJgGimDjXHfM3FhC7keQdWDea7+nXf+f1de7ATZcZkQ==",
       "dev": true
     },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -330,11 +411,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -417,20 +493,37 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "p-try": "^2.0.0"
       }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -441,6 +534,16 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "resolve": {
       "version": "1.9.0",
@@ -464,6 +567,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -483,6 +591,31 @@
       "version": "1.0.3",
       "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -600,15 +733,94 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
+    },
+    "yargs": {
+      "version": "15.3.1",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.2",
+      "resolved": "https://cfa.jfrog.io/cfa/api/npm/npm/yargs-parser/-/yargs-parser-18.1.2.tgz",
+      "integrity": "sha1-L0gr6iE2294IYWg6vqd1bTC1BPE=",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yn": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@types/chalk": "^2.2.0",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",
-    "@types/optimist": "0.0.29",
     "@types/sprintf-js": "^1.1.0",
+    "@types/yargs": "^15.0.4",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
     "js-yaml": "^3.8.4",
@@ -61,10 +61,10 @@
     "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev"
   },
   "dependencies": {
-    "tslint": "^5.9.1",
     "chalk": "^2.4.0",
-    "optimist": "^0.6.1",
+    "tslint": "^5.9.1",
     "tsutils": "^2.25.0",
-    "typescript": ">=2.8.3"
+    "typescript": ">=2.8.3",
+    "yargs": "^15.3.1"
   }
 }

--- a/src/rxjs-5-to-6-migrate.ts
+++ b/src/rxjs-5-to-6-migrate.ts
@@ -1,4 +1,4 @@
-import { argv } from 'optimist';
+import { argv } from 'yargs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import chalk from 'chalk';


### PR DESCRIPTION
Optimist has been deprecated over 2 years ago as has a security vulnerability. With this change we use it's successor yargs.

Closes: #70

Kindly merge and patch. 